### PR TITLE
src: Fix Docker builds

### DIFF
--- a/src/api/api.dockerfile
+++ b/src/api/api.dockerfile
@@ -5,7 +5,11 @@ FROM node:alpine as build
 WORKDIR /home/node/app
 
 # * copie files from the host to the container
-COPY . .
+COPY ./api ./api
+COPY ./shared ./shared
+
+# * switch to the app directory
+WORKDIR /home/node/app/api
 
 # * installs the dependencies
 RUN npm install
@@ -17,9 +21,9 @@ FROM node:alpine
 
 WORKDIR /home/node/app
 
-COPY --from=build --chown=node:node /home/node/app/dist dist
-COPY --from=build --chown=node:node /home/node/app/node_modules node_modules
-COPY --from=build --chown=node:node /home/node/app/package.json package.json
+COPY --from=build --chown=node:node /home/node/app/api/dist dist
+COPY --from=build --chown=node:node /home/node/app/api/node_modules node_modules
+COPY --from=build --chown=node:node /home/node/app/api/package.json package.json
 
 # * sets the environment variable to production
 ENV NODE_ENV=production

--- a/src/web-server/web-server.dockerfile
+++ b/src/web-server/web-server.dockerfile
@@ -5,7 +5,11 @@ FROM node:alpine as build
 WORKDIR /home/node/app
 
 # * copie files from the host to the container
-COPY . .
+COPY ./web-server ./web-server
+COPY ./shared ./shared
+
+# * switch to the app directory
+WORKDIR /home/node/app/web-server
 
 # * installs the dependencies
 RUN npm install
@@ -17,9 +21,9 @@ FROM node:alpine
 
 WORKDIR /home/node/app
 
-COPY --from=build --chown=node:node /home/node/app/dist dist
-COPY --from=build --chown=node:node /home/node/app/node_modules node_modules
-COPY --from=build --chown=node:node /home/node/app/package.json package.json
+COPY --from=build --chown=node:node /home/node/app/web-server/dist dist
+COPY --from=build --chown=node:node /home/node/app/web-server/node_modules node_modules
+COPY --from=build --chown=node:node /home/node/app/web-server/package.json package.json
 
 # * sets the environment variable to production
 ENV NODE_ENV=production


### PR DESCRIPTION
Change yesterday moved some configs into a shared directory. This broke the npm build since tsconfig wasn't available. To include both the shared configs ans the app code we need to build containers from the src directory.